### PR TITLE
Fixing broken CurseMaven builds

### DIFF
--- a/ChangeLog-1.12.2.txt
+++ b/ChangeLog-1.12.2.txt
@@ -1,4 +1,16 @@
-﻿2019/07/28 - 2.2.3 - Release
+﻿2022/07/09 - 2.2.5 Release
+  Corrected Essentia cell partitioning. Previously cells could be partitioned, but this was being ignored. Now
+  partitioned cells will only accept the filtered essentia.
+  Improved net handling code around Arcane Crafting Terminal to handle diffs of the AE2 inventory changes rather than
+  the entire inventory. Should be a bit faster.
+  Fixing Essentia export buses not respecting export cards. This continued to work on the first aspect in the list,
+  without checking if it was needed or not. Now this will pass to the next essentia if none would be transferred.
+
+  (build) Fixed a number of issues around the use of the CurseMaven plugin, probably fallout from the CurseForge API
+  changes lately. Builds simply broke with missing dependencies, and some version numbers for dependent mods seemed
+  shifted.
+
+2019/07/28 - 2.2.3 - Release
   You can now scan any item or block from AE2 to unlock research
   Added ME Controller as a Research Aid
   Added Buttons & Scroll to Essentia Terminal

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Preface
 ---
 This is a fork to try and improve the usability of Thaumic Energistics. This is currently being updated to help current
-players during Divine Journey 2.
+players during Divine Journey 2. Now also used by FTB Interactions 2.12+.
 
 Some warnings
 * I know development, but I don't know Minecraft modding. I've not done this before. I might break 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,8 @@
+Missing Items from 1.7
+
+* Essentia Level Emitters
+* Essentia Storage Monitors
+* Swapping Gear in ACT
+* Wireless Golem Backpack?
+* Essentia Conversion Monitor
+* Distillation Pattern Encoder

--- a/build.gradle
+++ b/build.gradle
@@ -12,11 +12,9 @@ buildscript {
     }
     dependencies {
         classpath "net.minecraftforge.gradle:ForgeGradle:${version_forgegradle}"
-        classpath "com.wynprice.cursemaven:CurseMaven:${version_cursemaven}"
     }
 }
 apply plugin: "net.minecraftforge.gradle.forge"
-apply plugin: "com.wynprice.cursemaven"
 
 version = "${version_the}"
 group = "thaumicenergistics"
@@ -46,6 +44,9 @@ runServer {
 
 repositories {
     maven {
+        url "https://cursemaven.com"
+    }
+    maven {
         name = "progwml6"
         url = "http://dvs1.progwml6.com/files/maven"
     }
@@ -65,11 +66,11 @@ repositories {
 
 dependencies {
     provided "mezz.jei:jei_${version_jei}:api"
-    provided "curse.maven:inventory-tweaks:${version_it}:api"
-    provided "curse.maven:hwyla:${version_hwyla}:api"
+    provided "curse.maven:inventory-tweaks-223094:${version_it}"
+    provided "curse.maven:hwyla-253449:${version_hwyla}"
     provided "mcjty.theoneprobe:TheOneProbe-${version_mc_no_patch}:${version_top}:api"
-    deobfCompile("curse.maven:baubles:${version_ba}")
-    deobfCompile("curse.maven:thaumcraft:${version_tc}")
+    deobfCompile("curse.maven:baubles-227083:${version_ba}")
+    deobfCompile("curse.maven:thaumcraft-223628:${version_tc}")
     deobfCompile("curse.maven:appliedenergistics2-223794:${version_ae2}") {
         transitive = false
     }
@@ -77,7 +78,7 @@ dependencies {
     // Testing mods
     runtime "mezz.jei:jei_${version_jei}"
     //runtime "curse.maven:inventory-tweaks:${version_it}" // Causes issues
-    runtime "curse.maven:hwyla:${version_hwyla}"
+    provided "curse.maven:hwyla-253449:${version_hwyla}"
     runtime "mcjty.theoneprobe:TheOneProbe-${version_mc_no_patch}:${version_top}"
     runtime("curse.maven:thaumic-jei:${version_tjei}") {
         transitive = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ version_cursemaven=2.1.+
 
 version_mc=1.12.2
 version_forge=14.23.5.2838
-version_the=v2.2.3-delfayne-fork-SNAPSHOT-2
+version_the=v2.2.5
 
 # Required Mods
 version_jei=1.12.2:+

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,13 +12,13 @@ version_the=v2.2.3-delfayne-fork-SNAPSHOT-2
 
 # Required Mods
 version_jei=1.12.2:+
-version_it=2482481
+version_it=2482482
 version_ba=2518667
 version_tc=2629023
 version_ae2=2747063
 
 # Optional/Runtime
-version_hwyla=2568751
+version_hwyla=2568753
 version_top=1.12-1.4.28-17
 version_tjei=2705304
 version_ccl=2779848

--- a/src/main/java/thaumicenergistics/init/ModGlobals.java
+++ b/src/main/java/thaumicenergistics/init/ModGlobals.java
@@ -14,7 +14,7 @@ public class ModGlobals {
 
     public static final String MOD_ID = "thaumicenergistics";
     public static final String MOD_NAME = "Thaumic Energistics";
-    public static final String MOD_VERSION = "2.2.3";
+    public static final String MOD_VERSION = "2.2.5";
     public static final String MOD_DEPENDENCIES = "required-after:appliedenergistics2@[rv6-stable-6,);" +
             "required-after:thaumcraft@[6.1.BETA26,);" +
             "after:thaumicjei;" +


### PR DESCRIPTION
This is primarily a build fix around CurseMaven. The build process randomly broke, presumably fallout from the CurseForge API changes.

This also will official bump the version to 2.2.5, as I'd rather support a real semantic version.

This contains no gameplay/mod changes.