### PR TITLE
Updates from recent DJ2 use

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ version_cursemaven=2.1.+
 
 version_mc=1.12.2
 version_forge=14.23.5.2838
-version_the=v2.2.5
+version_the=2.2.5
 
 # Required Mods
 version_jei=1.12.2:+

--- a/src/main/java/thaumicenergistics/client/gui/part/GuiArcaneTerminal.java
+++ b/src/main/java/thaumicenergistics/client/gui/part/GuiArcaneTerminal.java
@@ -154,7 +154,19 @@ public class GuiArcaneTerminal extends GuiAbstractTerminal<IAEItemStack, IItemSt
     protected void drawGuiContainerForegroundLayer(int mouseX, int mouseY) {
         super.drawGuiContainerForegroundLayer(mouseX, mouseY);
 
-        this.fontRenderer.drawString(ThEApi.instance().lang().guiVisRequiredOutOf().getLocalizedKey(this.visRequired > -1 ? this.visRequired : 0, (int) (this.visAvailable > -1 ? this.visAvailable : 0)), 35, this.getYSize() - 168, this.visRequired > this.visAvailable ? Color.RED.getRGB() : 4210752);
+        this.fontRenderer.drawString(
+                ThEApi.instance()
+                        .lang()
+                        .guiVisRequiredOutOf()
+                        .getLocalizedKey(
+                                getVisIfSet(this.visRequired),
+                                (int) (getVisIfSet(this.visAvailable))
+                        ),
+                35,
+                this.getYSize() - 168,
+                this.visRequired > this.visAvailable
+                        ? Color.RED.getRGB()
+                        : 4210752);
 
         if (this.discount > 0f)
             this.fontRenderer.drawString(ThEApi.instance().lang().guiVisDiscount().getLocalizedKey((int) (this.discount * 100)), 90, this.getYSize() - 94, 4210752);
@@ -225,7 +237,8 @@ public class GuiArcaneTerminal extends GuiAbstractTerminal<IAEItemStack, IItemSt
                     if (stack != null &&
                             action == ActionType.PICKUP_OR_SETDOWN &&
                             stack.getStackSize() == 0 &&
-                            player.inventory.getItemStack().isEmpty())
+                            player.inventory.getItemStack().isEmpty() &&
+                            sufficientVis())
                         action = ActionType.AUTO_CRAFT;
                     break;
                 case QUICK_MOVE:
@@ -378,5 +391,14 @@ public class GuiArcaneTerminal extends GuiAbstractTerminal<IAEItemStack, IItemSt
     public void updateScroll() {
         this.scrollBar.setRows(this.rows);
         this.scrollBar.setRange(0, (this.repo.size() + 8) / 9 - this.rows, Math.max(1, this.rows / 6));
+    }
+
+
+    private float getVisIfSet(float vis) {
+        return vis > -1 ? vis : 0;
+    }
+
+    private boolean sufficientVis() {
+        return visAvailable - (visRequired * (1f - discount)) > 0f;
     }
 }

--- a/src/main/java/thaumicenergistics/container/slot/SlotGhostEssentia.java
+++ b/src/main/java/thaumicenergistics/container/slot/SlotGhostEssentia.java
@@ -8,20 +8,17 @@ import thaumcraft.api.aspects.Aspect;
 import thaumicenergistics.util.AEUtil;
 import thaumicenergistics.util.EssentiaFilter;
 
+import javax.annotation.Nonnull;
+
 /**
  * @author BrockWS
  */
 public class SlotGhostEssentia extends SlotGhost {
 
-    private EssentiaFilter filter;
+    private final EssentiaFilter filter;
 
     public SlotGhostEssentia(EssentiaFilter filter, IInventory inventory, int index, int xPosition, int yPosition, int groupID) {
         super(inventory, index, xPosition, yPosition, groupID);
-        this.filter = filter;
-    }
-
-    public SlotGhostEssentia(EssentiaFilter filter, IInventory inventoryIn, int index, int xPosition, int yPosition) {
-        super(inventoryIn, index, xPosition, yPosition);
         this.filter = filter;
     }
 
@@ -33,7 +30,12 @@ public class SlotGhostEssentia extends SlotGhost {
         return this.getFilter().getAspect(this.getSlotIndex());
     }
 
+    public void setAspect(Aspect aspect) {
+        getFilter().setAspect(aspect, this.getSlotIndex());
+    }
+
     @Override
+    @Nonnull
     public ItemStack getStack() {
         if (this.getAspect() != null)
             return AEUtil.getAEStackFromAspect(this.getAspect(), 0).asItemStackRepresentation();

--- a/src/main/java/thaumicenergistics/integration/jei/GhostEssentiaHandler.java
+++ b/src/main/java/thaumicenergistics/integration/jei/GhostEssentiaHandler.java
@@ -47,15 +47,20 @@ public class GhostEssentiaHandler implements IGhostIngredientHandler<GuiSharedEs
                 return gui.inventorySlots.inventorySlots.stream()
                         .filter(it -> it instanceof SlotGhostEssentia)
                         .filter(Slot::isEnabled)
+                        .filter(it -> {
+                            ItemTCEssentiaContainer essentiaContainer = (ItemTCEssentiaContainer) item;
+                            AspectList aspectList = essentiaContainer.getAspects(itemStack);
+                            return aspectList != null;
+                        })
                         .map(it -> (SlotGhost) it)
-                        .map(it -> new Target<I>() {
+                        .map(slot -> new Target<I>() {
 
                             @Override
                             @Nonnull
                             public Rectangle getArea() {
                                 return new Rectangle(
-                                        gui.getGuiLeft() + it.xPos,
-                                        gui.getGuiTop() + it.yPos,
+                                        gui.getGuiLeft() + slot.xPos,
+                                        gui.getGuiTop() + slot.yPos,
                                         17,
                                         17
                                 );
@@ -67,10 +72,14 @@ public class GhostEssentiaHandler implements IGhostIngredientHandler<GuiSharedEs
                                 ItemStack itemStack = (ItemStack) ingredient;
                                 Item item = itemStack.getItem();
                                 ItemTCEssentiaContainer essentiaContainer = (ItemTCEssentiaContainer) item;
-                                Aspect aspect = essentiaContainer.getAspects(itemStack).getAspects()[0];
-                                ThELog.debug("TC Essentia container: {}", aspect);
+                                AspectList aspectList = essentiaContainer.getAspects(itemStack);
+                                if (aspectList != null) {
+                                    Aspect[] aspects = aspectList.getAspects();
+                                    Aspect aspect = aspects[0];
+                                    ThELog.debug("TC Essentia container: {}", aspect);
 
-                                PacketHandler.sendToServer(new PacketGhostEssentia(aspect, it.slotNumber));
+                                    PacketHandler.sendToServer(new PacketGhostEssentia(aspect, slot.slotNumber));
+                                }
                             }
                         });
             }

--- a/src/main/java/thaumicenergistics/integration/jei/GhostEssentiaHandler.java
+++ b/src/main/java/thaumicenergistics/integration/jei/GhostEssentiaHandler.java
@@ -1,0 +1,70 @@
+package thaumicenergistics.integration.jei;
+
+import mezz.jei.api.gui.IGhostIngredientHandler;
+import net.minecraft.inventory.Slot;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumicenergistics.client.gui.part.GuiSharedEssentiaBus;
+import thaumicenergistics.container.slot.SlotGhost;
+import thaumicenergistics.container.slot.SlotGhostEssentia;
+import thaumicenergistics.network.PacketHandler;
+import thaumicenergistics.network.packets.PacketGhostEssentia;
+
+import javax.annotation.Nonnull;
+import java.awt.*;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+public class GhostEssentiaHandler implements IGhostIngredientHandler<GuiSharedEssentiaBus> {
+
+    @Override
+    @Nonnull
+    public <I> List<Target<I>> getTargets(
+            @Nonnull GuiSharedEssentiaBus gui,
+            @Nonnull I ingredient,
+            boolean doStart) {
+
+        Stream<Target<I>> essentiaTargets = getForAspectList(gui, ingredient);
+
+        return Stream.concat(essentiaTargets, Stream.empty())
+                .collect(toList());
+    }
+
+    private <I> Stream<Target<I>> getForAspectList(GuiSharedEssentiaBus gui, I ingredient) {
+
+        if (ingredient instanceof AspectList) {
+            return gui.inventorySlots.inventorySlots.stream()
+                    .filter(it -> it instanceof SlotGhostEssentia)
+                    .filter(Slot::isEnabled)
+                    .map(it -> (SlotGhost) it)
+                    .map(it -> new Target<I>() {
+
+                        @Override
+                        @Nonnull
+                        public Rectangle getArea() {
+                            return new Rectangle(
+                                    gui.getGuiLeft() + it.xPos,
+                                    gui.getGuiTop() + it.yPos,
+                                    17,
+                                    17
+                            );
+                        }
+
+                        @Override
+                        public void accept(@Nonnull I ingredient) {
+                            AspectList aspectList = (AspectList) ingredient;
+                            Aspect aspect = aspectList.getAspects()[0];
+                            PacketHandler.sendToServer(new PacketGhostEssentia(aspect, it.slotNumber));
+                        }
+                    });
+        }
+        return Stream.empty();
+    }
+
+    @Override
+    public void onComplete() {
+
+    }
+}

--- a/src/main/java/thaumicenergistics/integration/jei/ThEJEI.java
+++ b/src/main/java/thaumicenergistics/integration/jei/ThEJEI.java
@@ -2,20 +2,21 @@ package thaumicenergistics.integration.jei;
 
 import com.google.common.base.Strings;
 import mezz.jei.api.IJeiRuntime;
-import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
-import net.minecraft.inventory.Container;
-import net.minecraft.item.ItemStack;
-import thaumicenergistics.api.IThEItems;
-import thaumicenergistics.api.ThEApi;
-
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.IModRegistry;
 import mezz.jei.api.JEIPlugin;
 import mezz.jei.api.ingredients.IIngredientBlacklist;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 import mezz.jei.api.recipe.transfer.IRecipeTransferHandler;
+import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
+import net.minecraft.inventory.Container;
+import net.minecraft.item.ItemStack;
+import thaumicenergistics.api.IThEItems;
+import thaumicenergistics.api.ThEApi;
+import thaumicenergistics.client.gui.part.GuiSharedEssentiaBus;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+
 
 /**
  * @author BrockWS
@@ -27,15 +28,15 @@ public class ThEJEI implements IModPlugin {
 
     @Override
     @ParametersAreNonnullByDefault
-    public void onRuntimeAvailable(IJeiRuntime jeiRuntime){
+    public void onRuntimeAvailable(IJeiRuntime jeiRuntime) {
         runtime = jeiRuntime;
     }
 
-    public static String getSearchText(){
+    public static String getSearchText() {
         return Strings.nullToEmpty(runtime.getIngredientFilter().getFilterText());
     }
 
-    public static void setSearchText(String searchText){
+    public static void setSearchText(String searchText) {
         runtime.getIngredientFilter().setFilterText(Strings.nullToEmpty(searchText));
     }
 
@@ -48,12 +49,15 @@ public class ThEJEI implements IModPlugin {
         items.arcaneTerminal().maybeStack(1).ifPresent(stack -> registerWorkbenchCatalyst(registry, new ACTRecipeTransferHandler<>(rthh), stack));
         items.arcaneInscriber().maybeStack(1).ifPresent(stack -> registerWorkbenchCatalyst(registry, new ACIRecipeTransferHandler<>(rthh), stack));
 
+        items.essentiaExportBus().maybeStack(1).ifPresent(stack -> registry.addGhostIngredientHandler(GuiSharedEssentiaBus.class, new GhostEssentiaHandler()));
+
         items.dummyAspect().maybeStack(1).ifPresent(blacklist::addIngredientToBlacklist);
     }
 
-    public void registerWorkbenchCatalyst(IModRegistry registry, IRecipeTransferHandler<? extends Container> handler, ItemStack stack){
+    public void registerWorkbenchCatalyst(IModRegistry registry, IRecipeTransferHandler<? extends Container> handler, ItemStack stack) {
         registry.getRecipeTransferRegistry().addRecipeTransferHandler(handler, VanillaRecipeCategoryUid.CRAFTING);
         registry.getRecipeTransferRegistry().addRecipeTransferHandler(handler, "THAUMCRAFT_ARCANE_WORKBENCH");
         registry.addRecipeCatalyst(stack, "THAUMCRAFT_ARCANE_WORKBENCH");
     }
+
 }

--- a/src/main/java/thaumicenergistics/network/PacketHandler.java
+++ b/src/main/java/thaumicenergistics/network/PacketHandler.java
@@ -49,6 +49,7 @@ public class PacketHandler {
         PacketHandler.INSTANCE.registerMessage(PacketSubscribe.Handler.class, PacketSubscribe.class, PacketHandler.nextID(), Side.SERVER);
         PacketHandler.INSTANCE.registerMessage(PacketEssentiaFilterAction.Handler.class, PacketEssentiaFilterAction.class, PacketHandler.nextID(), Side.SERVER);
         PacketHandler.INSTANCE.registerMessage(PacketAssemblerGUIUpdateRequest.Handler.class, PacketAssemblerGUIUpdateRequest.class, PacketHandler.nextID(), Side.SERVER);
+        PacketHandler.INSTANCE.registerMessage(PacketGhostEssentia.Handler.class, PacketGhostEssentia.class, PacketHandler.nextID(), Side.SERVER);
     }
 
     public static void sendToPlayer(EntityPlayerMP player, IMessage message) {

--- a/src/main/java/thaumicenergistics/network/packets/PacketGhostEssentia.java
+++ b/src/main/java/thaumicenergistics/network/packets/PacketGhostEssentia.java
@@ -1,0 +1,73 @@
+package thaumicenergistics.network.packets;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.Slot;
+import net.minecraft.util.IThreadListener;
+import net.minecraftforge.fml.common.network.ByteBufUtils;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
+import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+import thaumcraft.api.aspects.Aspect;
+import thaumicenergistics.container.part.ContainerSharedEssentiaBus;
+import thaumicenergistics.container.slot.SlotGhostEssentia;
+import thaumicenergistics.util.ThELog;
+
+public class PacketGhostEssentia implements IMessage {
+
+    private Aspect aspect;
+    private int slot;
+
+    @SuppressWarnings("unused")
+    public PacketGhostEssentia() {
+    }
+
+    public PacketGhostEssentia(Aspect aspect, int slot) {
+        this.aspect = aspect;
+        this.slot = slot;
+    }
+
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        String tag = ByteBufUtils.readUTF8String(buf);
+        ThELog.debug("Read aspect '{}' from bytes", tag);
+        aspect = Aspect.getAspect(tag);
+        slot = buf.readInt();
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        ByteBufUtils.writeUTF8String(buf, aspect.getTag());
+        buf.writeInt(slot);
+    }
+
+    public static class Handler implements IMessageHandler<PacketGhostEssentia, IMessage> {
+
+        @Override
+        public IMessage onMessage(PacketGhostEssentia message, MessageContext ctx) {
+            EntityPlayerMP player = ctx.getServerHandler().player;
+
+
+            IThreadListener threadListener = (IThreadListener) player.world;
+            threadListener.addScheduledTask(() -> {
+                Container openContainer = player.openContainer;
+                ThELog.debug("Server received aspect '{}' using slot '{}'", message.aspect.getName(), openContainer);
+                if ((!(openContainer instanceof ContainerSharedEssentiaBus))) {
+                    return;
+                }
+
+                if (message.slot >= 0 && message.slot < openContainer.inventorySlots.size()) {
+                    Slot invSlot = openContainer.getSlot(message.slot);
+                    if (invSlot instanceof SlotGhostEssentia) {
+                        SlotGhostEssentia ghostEssentiaSlot = (SlotGhostEssentia) invSlot;
+                        ghostEssentiaSlot.setAspect(message.aspect);
+                    }
+                }
+            });
+
+            return null;
+        }
+    }
+}

--- a/src/main/resources/assets/thaumicenergistics/lang/en_us.lang
+++ b/src/main/resources/assets/thaumicenergistics/lang/en_us.lang
@@ -120,38 +120,38 @@ research.essentiastorage64k.stage.2=I can now store massive amounts of essentia 
 
 # Research Essentia Buses
 research.essentiabuses.title=Digisentia Transportation
-research.essentiabuses.stage.1=Now that I can digitize essentia, it's time to put that technology to work
-research.essentiabuses.stage.2=I can now make Essentia Buses
+research.essentiabuses.stage.1=Now that I have the components to safely transport essentia with my ME system, I can now work on creating buses for essentia.
+research.essentiabuses.stage.2=I can now make Import, Export, and Storage Buses. They all function exactly like their item counterparts.
 
 # Research Essentia Terminal
 research.essentiaterminal.title=Essentia Monitoring
-research.essentiaterminal.stage.1=Now that I can digitize essentia, it's time to put that technology to work
-research.essentiaterminal.stage.2=I can now make Essentia Terminals
+research.essentiaterminal.stage.1=While I can now digitize essentia, I have realized this means I can no longer observe the quantities of essentia I have digitalized - an urgent problem.
+research.essentiaterminal.stage.2=The ME Essentia Terminal allows me to see all essentia my ME network can access. Additionally, I can insert and extract essentia with phials through it.
 
 # Research Infusion Provider
 research.infusionprovider.title=Infusion Provider
-research.infusionprovider.stage.1=Now that I can digitize essentia, it's time to put that technology to work
-research.infusionprovider.stage.2=I can now make Infusion Provider
+research.infusionprovider.stage.1=While being able to manipulate essentia with my ME system has proven invaluable, I am frustrated with the process required for Infusion - I have to extract all my essentia into jars on-site. Perhaps if I could expose my essentia to the Runic Matrix similar to the Essentia Terminal...
+research.infusionprovider.stage.2=Success! The Essentia Infusion Provider will expose the entire ME network's essentia to the Infusion process! As a bonus, it also works with my ME Essentia Storage Buses, allowing me to create essentia subnetworks, should I ever need those.
 
 # Research Arcane Crafting Terminal
 research.arcaneterminal.title=Arcane Crafting Terminal
-research.arcaneterminal.stage.1=Maybe I can combine a ME Terminal with a Arcane Workbench to get something that will help me with my arcane endeavours
-research.arcaneterminal.stage.2=I can now make Arcane Crafting Terminal
-research.arcaneterminal.addenda.1=I can upgrade my Arcane Crafting Terminal to increase its vis draw range
+research.arcaneterminal.stage.1=Having to hop back and forth between my ME system and my Arcane Workbench for every craft is getting frustrating. While it is vastly more complex than a mere Crafting Terminal, using the same principles, I should be able to hook my Arcane Workbench into my ME system.
+research.arcaneterminal.stage.2=The Arcane Crafting Terminal allows my Arcane Workbench to take full advantage of my ME system.
+research.arcaneterminal.addenda.1=I can upgrade my Arcane Crafting Terminal with the Arcane Charging Upgrade to allow it to access and draw vis from all neighboring chunks.
 
 # Research Arcane Assembler
 research.arcaneassembler.title=Arcane Assembler
-research.arcaneassembler.stage.1=Mixing technology and magic has proven a challenge, but so far it's been going well, so what could possibly go wrong if I take it a step further? I'm currently fed up with having to craft a bunch of things on my own, surely I can come up with a way to make a Molecular Assembler able to craft arcane objects!
-research.arcaneassembler.stage.2=As I suspected, arcane recipes don't play nicely with Matter/Energy devices, explosions may have happened. I'm sure I'll figure out a way to make it happen eventually, though. For now however, after studying Matter/Energy a bunch, I came up with a design for a Molecular Assembler that can use Vis Crystals. There's yet another issue though... it doesn't know how to craft the things I know how to craft. It's like it's missing something.
-research.arcaneassembler.addenda.1=I can upgrade my Arcane Assembler to increase its vis draw range, like with my Arcane Crafting Terminal
-research.arcaneassembler.addenda.2=Note: when I request something to be crafted, my ME system will not show the cost of Vis and Vis Crystals, even though those are still required. If I have a problem crafting things, I should take a look at the Arcane Assembler's interface, since it might have the answer. Lastly, I can upgrade the Arcane Assembler with Acceleration Cards to make it even faster.
+research.arcaneassembler.stage.1=While being able to manually craft arcane items with my ME network is very helpful, the true power of ME is its auto-crafting ability. I should look into some way to make a Molecular Assembler able to craft arcane objects.
+research.arcaneassembler.stage.2=Everything ought to work - it can get the items, the vis, the Essentia crystals, the power. Yet it doesn't even attempt to craft! I have invented nothing more than a, albeit quite heavy, paperweight. A paperweight which can be augmented with multiple Acceleration Cards. This has been a massive disappointment.
+research.arcaneassembler.addenda.1=I can upgrade my Arcane Assembler with the Arcane Charging Upgrade to allow it to access and draw vis from all neighbouring chunks.
+research.arcaneassembler.addenda.2=Now that I have seen the Arcane Assembler in use, I have realised a pair of problems - the first being that Vis is consumed at an alarming rate while auto-crafting, often slowing down the process massively, and the second being that Vis Crystals are not shown in the recipe cost. I will need to figure out ways to avoid both of these problems to efficiently auto-craft.
 
 # Research Knowledge Core
 research.knowledgecore.title=Knowledge Core
-research.knowledgecore.stage.1=I've been thinking about my current paperweight: the Arcane Assembler. I've been thinking about it... a lot. The whispers are not helping either. I think my mind needs some rest, but I can't sleep until I figure this one out! Hmm, mind... I can't fuse my brain into the Arcane Assembler, that would defeat the purpose and I kind of still need it. I can't teach the Arcane Assembler what I know, because it doesn't have a brain. Perhaps I can fix that. Yes! Sleep can wait, I must hunt for brains! I have experiments to run, there is research to be done.
-research.knowledgecore.stage.2=This was a triumph! After smashing a bunch of brains and circuits together for a few hours, I found out how to make this machine work. I've come up with a device that I call the Knowledge Core. The device will work fine for arcane recipes, but I can't use it for anything else, the brain in it explodes into pieces when I try that, but I'll make sure that can't happen. I've cleaned up my jars enough times. Oh right the brain! I forgot to mention, I will need a fresh brain. Well, fresh enough. I'm sure an undead's brain wouldn't mind crafting things for me, on my command, for years to come.
+research.knowledgecore.stage.1=I've been thinking about my current paperweight, the Arcane Assembler. Perhaps the issue is that it doesn't know how to craft - it hasn't spent hours researching, after all. I should look into ways to allow the Arcane Assembler to research.
+research.knowledgecore.stage.2=Eureka! I don't need to have the Arcane Assembler research - likely an impossible task - I merely need to create something that can remember a craft I've done, and do it exactly the same way. A zombie brain is perfect for this - all I have to do is teach the brain to do exactly the recipe I show it.
 
 # Research Arcane Inscriber
 research.arcaneinscriber.title=Arcane Inscriber
-research.arcaneinscriber.stage.1=After getting some sleep I realized something. It seems that the undead are not very bright. I've been talking to this Knowledge Core for a while now, but it doesn't seem to learn anything I teach it. At this rate I will never have a machine that crafts things for me. I need to find a way to force my knowledge straight into the Knowledge Core.
-research.arcaneinscriber.stage.2=I did it! I designed a kind of terminal that can, instead of crafting things, teach recipes to a Knowledge Core. I can also view what they know or make them forget, you never know when that will come in handy. The amount these cores can learn is not infinite, but it's still better than talking to them for years or crafting everything myself. I should also note that I can only teach the Knowledge Cores what I already know, but no more.
+research.arcaneinscriber.stage.1=It appears the undead are not very bright. I've been trying to teach this Knowledge Core how to craft for a while now, yet it hasn't learned anything. I need to find a way to force the Knowledge Core to learn.
+research.arcaneinscriber.stage.2=Basing my design off of an ME Pattern Terminal, I have managed to design a kind of terminal that can teach recipes to a Knowledge Core. I simply load the recipe into the grid and then save it! I can also examine what recipes I have saved to a Knowledge Core, and if so desired, erase recipes from the zombie's memory. While a single zombie brain is limited in how many recipes it can remember, zombies are plentiful.

--- a/src/main/resources/assets/thaumicenergistics/research/thaumicenergistics.json
+++ b/src/main/resources/assets/thaumicenergistics/research/thaumicenergistics.json
@@ -64,10 +64,6 @@
                     ]
                 }
             ],
-            "reward_item": [
-                "thaumicenergistics:diffusion_core;2",
-                "thaumicenergistics:coalescence_core;2"
-            ],
             "reward_knowledge": [
                 "OBSERVATION;THAUMICENERGISTICS;1"
             ]
@@ -109,9 +105,6 @@
                         "thaumicenergistics:cells/essentia_cell_1k"
                     ]
                 }
-            ],
-            "reward_item": [
-                "thaumicenergistics:essentia_component_1k"
             ],
             "reward_knowledge": [
                 "OBSERVATION;THAUMICENERGISTICS;1"
@@ -156,9 +149,6 @@
                     ]
                 }
             ],
-            "reward_item": [
-                "thaumicenergistics:essentia_component_4k"
-            ],
             "reward_knowledge": [
                 "OBSERVATION;THAUMICENERGISTICS;1"
             ]
@@ -202,9 +192,6 @@
                     ]
                 }
             ],
-            "reward_item": [
-                "thaumicenergistics:essentia_component_16k"
-            ],
             "reward_knowledge": [
                 "OBSERVATION;THAUMICENERGISTICS;1"
             ]
@@ -247,9 +234,6 @@
                         "thaumicenergistics:cells/essentia_cell_64k"
                     ]
                 }
-            ],
-            "reward_item": [
-                "thaumicenergistics:essentia_component_64k"
             ],
             "reward_knowledge": [
                 "OBSERVATION;THAUMICENERGISTICS;2"


### PR DESCRIPTION
Game changes
* Adding an extra check against the client's last known Vis levels. This should prevent item ghosting when trying to pick up the result of a craft from the ACT when vis levels are insufficient
* Updating a number of Thaumic Energistics based journal entries, primarily based on DJ2 authors recommendations. Most make sense. The original ones were lacking some flavour
* Removing freebie quest items from completing ThE research. I agree here that this can screw with ModPack authors' progression if difficult to craft items are given without configuration. 
* Added the ability to configure Essentia Export/Import/Storage Buses from JEI. You may now click and drag Essentia Phials, Vis Crystals or the non-item JEI Essentia bubbles to configure a bus

Build changes
* Really corrected SemVer this time