### PR TITLE
Delfayne/terminal crash

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,6 +74,11 @@ minecraft {
         args += "-Dmixin.checks.interfaces=true"
         args += "-Dmixin.debug.export=true"
     }
+    if (projectProperty("useMixins")) {
+        args += "-Dmixin.hotSwap=true"
+        args += "-Dmixin.checks.interfaces=true"
+        args += "-Dmixin.debug.export=true"
+    }
     extraRunJvmArguments.addAll(args)
 
     // Include and use dependencies Access Transformer files
@@ -144,8 +149,8 @@ dependencies {
         // Change your mixin refmap name here:
         val mixin: String =
             modUtils.enableMixins(
-                "zone.rong:mixinbooter:8.9",
-                "mixins.${modArchiveName}.refmap.json"
+                libs.mixinBooter.get().toString(),
+                "mixins.${archiveBase}.refmap.json"
             ).toString()
         api(mixin) {
             isTransitive = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,7 @@ forgeVersion=14.23.5.2860
 archiveBase=thaumicenergistics
 # Access Transformer files should be in the root of `resources` folder and with the filename formatted as: `{archives_base_name}_at.cfg`
 useAccessTransformer=true
+useMixins=true
 # In Game Information Book, Optional
 version_rf=2920436
 version_bc=1.12.2-2.4.19.214

--- a/src/main/java/thaumicenergistics/annotation/ClientOnlyMixin.java
+++ b/src/main/java/thaumicenergistics/annotation/ClientOnlyMixin.java
@@ -1,0 +1,13 @@
+package thaumicenergistics.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+// https://github.com/embeddedt/VintageFix/blob/15291a5829ead82cf7dde9b482a2a2cc95ea45b7/src/main/java/org/embeddedt/vintagefix/annotation/ClientOnlyMixin.java
+@Retention(CLASS)
+@Target(TYPE)
+public @interface ClientOnlyMixin {
+}

--- a/src/main/java/thaumicenergistics/annotation/LateMixin.java
+++ b/src/main/java/thaumicenergistics/annotation/LateMixin.java
@@ -1,0 +1,13 @@
+package thaumicenergistics.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+// https://github.com/embeddedt/VintageFix/blob/15291a5829ead82cf7dde9b482a2a2cc95ea45b7/src/main/java/org/embeddedt/vintagefix/annotation/LateMixin.java
+@Retention(CLASS)
+@Target(TYPE)
+public @interface LateMixin {
+}

--- a/src/main/java/thaumicenergistics/client/gui/crafting/GuiCraftAmountBridge.java
+++ b/src/main/java/thaumicenergistics/client/gui/crafting/GuiCraftAmountBridge.java
@@ -1,13 +1,12 @@
 package thaumicenergistics.client.gui.crafting;
 
 import appeng.client.gui.implementations.GuiCraftAmount;
-import appeng.client.gui.widgets.GuiNumberBox;
 import appeng.client.gui.widgets.GuiTabButton;
 import appeng.core.localization.GuiText;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.fml.relauncher.ReflectionHelper;
+import thaumicenergistics.mixin.ae2.CraftAmountAccessor;
 import thaumicenergistics.network.PacketHandler;
 import thaumicenergistics.network.packets.PacketCraftRequest;
 import thaumicenergistics.network.packets.PacketOpenGUI;
@@ -22,7 +21,6 @@ public class GuiCraftAmountBridge extends GuiCraftAmount {
 
     private final EntityPlayer player;
     private final PartSharedTerminal part;
-    private GuiNumberBox craftAmount;
 
     public GuiCraftAmountBridge(EntityPlayer player, PartSharedTerminal part) {
         super(player.inventory, part);
@@ -33,9 +31,7 @@ public class GuiCraftAmountBridge extends GuiCraftAmount {
     @Override
     public void initGui() {
         super.initGui();
-        this.craftAmount = ReflectionHelper.getPrivateValue(GuiCraftAmount.class, this, "amountToCraft");
-        if (this.craftAmount == null)
-            throw new RuntimeException("Failed to get private value amountToCraft");
+
         ItemStack icon = part.getRepr();
         if (!icon.isEmpty())
             this.buttonList.add(new GuiTabButton(this.guiLeft + 154, this.guiTop, icon, icon.getDisplayName(), this.itemRender));
@@ -44,7 +40,7 @@ public class GuiCraftAmountBridge extends GuiCraftAmount {
     @Override
     protected void actionPerformed(GuiButton btn) throws IOException {
         if (btn.displayString.equals(GuiText.Next.getLocal()) || btn.displayString.equals(GuiText.Start.getLocal())) {
-            PacketHandler.sendToServer(new PacketCraftRequest(Integer.parseInt(this.craftAmount.getText()), isShiftKeyDown()));
+            PacketHandler.sendToServer(new PacketCraftRequest(getAmountToCraft(), isShiftKeyDown()));
             return;
         }
 
@@ -55,5 +51,11 @@ public class GuiCraftAmountBridge extends GuiCraftAmount {
         }
 
         super.actionPerformed(btn);
+    }
+
+    private int getAmountToCraft() {
+        return Integer.parseInt(
+                ((CraftAmountAccessor) this).getAmountToCraft().getText()
+        );
     }
 }

--- a/src/main/java/thaumicenergistics/mixin/ae2/CraftAmountAccessor.java
+++ b/src/main/java/thaumicenergistics/mixin/ae2/CraftAmountAccessor.java
@@ -1,0 +1,16 @@
+package thaumicenergistics.mixin.ae2;
+
+import appeng.client.gui.implementations.GuiCraftAmount;
+import appeng.client.gui.widgets.GuiNumberBox;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import thaumicenergistics.annotation.ClientOnlyMixin;
+import thaumicenergistics.annotation.LateMixin;
+
+@Mixin(GuiCraftAmount.class)
+@ClientOnlyMixin
+@LateMixin
+public interface CraftAmountAccessor {
+    @Accessor(remap = false)
+    GuiNumberBox getAmountToCraft();
+}

--- a/src/main/java/thaumicenergistics/mixin/core/LateMixins.java
+++ b/src/main/java/thaumicenergistics/mixin/core/LateMixins.java
@@ -1,0 +1,17 @@
+package thaumicenergistics.mixin.core;
+
+import com.google.common.collect.ImmutableList;
+import zone.rong.mixinbooter.ILateMixinLoader;
+
+import java.util.List;
+
+// https://github.com/embeddedt/VintageFix/blob/15291a5829ead82cf7dde9b482a2a2cc95ea45b7/src/main/java/org/embeddedt/vintagefix/core/LateMixins.java
+public class LateMixins implements ILateMixinLoader {
+    static boolean atLateStage = false;
+
+    @Override
+    public List<String> getMixinConfigs() {
+        atLateStage = true;
+        return ImmutableList.of("mixins.thaumicenergistics.late.json");
+    }
+}

--- a/src/main/java/thaumicenergistics/mixin/core/MixinConfigPlugin.java
+++ b/src/main/java/thaumicenergistics/mixin/core/MixinConfigPlugin.java
@@ -1,0 +1,194 @@
+package thaumicenergistics.mixin.core;
+
+import com.google.common.collect.ImmutableMap;
+import net.minecraft.launchwrapper.Launch;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dv.minecraft.thaumicenergistics.thaumicenergistics.Reference;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.MixinEnvironment;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.io.*;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.FileSystem;
+import java.nio.file.*;
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+// https://github.com/embeddedt/VintageFix/blob/15291a5829ead82cf7dde9b482a2a2cc95ea45b7/src/main/java/org/embeddedt/vintagefix/core/MixinConfigPlugin.java
+public class MixinConfigPlugin implements IMixinConfigPlugin {
+    private static final Logger LOGGER = LogManager.getLogger(Reference.NAME + " Mixin Loader");
+
+    private static final String PACKAGE_PREFIX = "thaumcraft.";
+
+    private static final ImmutableMap<String, Consumer<PotentialMixin>> MIXIN_PROCESSING_MAP = ImmutableMap.<String, Consumer<PotentialMixin>>builder()
+            .put("Lorg/spongepowered/asm/mixin/Mixin;", p -> p.valid = true)
+            .put("Lthaumicenergistics/annotation/ClientOnlyMixin;", p -> p.isClientOnly = true)
+            .put("Lthaumicenergistics/annotation/LateMixin;", p -> p.isLate = true)
+            .build();
+
+    static class PotentialMixin {
+        String className;
+        boolean valid;
+        boolean isClientOnly;
+        boolean isLate;
+    }
+
+    private static final List<PotentialMixin> allMixins = new ArrayList<>();
+
+    private void considerClass(String pathString) throws IOException {
+        try (InputStream stream = MixinConfigPlugin.class.getClassLoader().getResourceAsStream("thaumicenergistics/mixin/" + pathString)) {
+            if (stream == null)
+                return;
+            ClassReader reader = new ClassReader(stream);
+            ClassNode node = new ClassNode();
+            reader.accept(node, ClassReader.SKIP_CODE | ClassReader.SKIP_FRAMES | ClassReader.SKIP_DEBUG);
+            if (node.invisibleAnnotations == null)
+                return;
+            PotentialMixin mixin = new PotentialMixin();
+            mixin.className = node.name.replace('/', '.');
+            for (AnnotationNode annotation : node.invisibleAnnotations) {
+                Consumer<PotentialMixin> consumer = MIXIN_PROCESSING_MAP.get(annotation.desc);
+                if (consumer != null)
+                    consumer.accept(mixin);
+            }
+            if (mixin.valid)
+                allMixins.add(mixin);
+        }
+    }
+
+    private static Properties config;
+
+    private static String mixinClassNameToBaseName(String mixinClassName) {
+        String noPrefix = mixinClassName.replace(PACKAGE_PREFIX, "");
+        return noPrefix.substring(0, noPrefix.lastIndexOf('.'));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void writeOrderedProperties(Properties props, OutputStream stream) throws IOException {
+        try (PrintWriter writer = new PrintWriter(stream)) {
+            writer.println("# Thaumic Energistics config file");
+            writer.println();
+            List<String> lst = new ArrayList<>((Set<String>) (Set<?>) props.keySet());
+            lst.sort(Comparator.naturalOrder());
+            for (String k : lst) {
+                writer.println(k + "=" + props.getProperty(k));
+            }
+        }
+    }
+
+    @Override
+    public void onLoad(String s) {
+        if (allMixins.size() == 0) {
+            try {
+                URI uri = Objects.requireNonNull(MixinConfigPlugin.class.getResource("/mixins.thaumicenergistics.json")).toURI();
+                FileSystem fs;
+                try {
+                    fs = FileSystems.getFileSystem(uri);
+                } catch (FileSystemNotFoundException var11) {
+                    fs = FileSystems.newFileSystem(uri, Collections.emptyMap());
+                }
+                List<Path> list;
+                Path basePath = fs.getPath("thaumicenergistics", "mixin").toAbsolutePath();
+                try (Stream<Path> stream = Files.walk(basePath)) {
+                    list = stream.collect(Collectors.toList());
+                }
+                for (Path p : list) {
+                    if (p == null)
+                        continue;
+                    p = basePath.relativize(p.toAbsolutePath());
+                    String pathString = p.toString();
+                    if (pathString.endsWith(".class")) {
+                        considerClass(pathString);
+                    }
+                }
+            } catch (IOException | URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+            LOGGER.info("Found {} mixins", allMixins.size());
+            config = new Properties();
+            File targetConfig = new File(Launch.minecraftHome, "config" + File.separator + "thaumicenergistics.properties");
+            try {
+                if (targetConfig.exists()) {
+                    try (InputStream stream = Files.newInputStream(targetConfig.toPath())) {
+                        config.load(stream);
+                    } catch (IllegalArgumentException ignored) {
+                    }
+                }
+                for (PotentialMixin m : allMixins) {
+                    String baseName = mixinClassNameToBaseName(m.className);
+                    if (!config.containsKey(baseName)) {
+                        LOGGER.warn("Added missing entry '{}' to config file", baseName);
+                        config.put(baseName, "true");
+                    }
+                }
+                try (OutputStream stream = Files.newOutputStream(targetConfig.toPath())) {
+                    writeOrderedProperties(config, stream);
+                }
+                LOGGER.info("Successfully saved config file");
+            } catch (IOException e) {
+                LOGGER.error("Exception handling config", e);
+            }
+        }
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetName, String className) {
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> set, Set<String> set1) {
+    }
+
+    public static boolean isMixinClassApplied(String name) {
+        String baseName = mixinClassNameToBaseName(name);
+        boolean isEnabled = Boolean.parseBoolean(config.getProperty(baseName, ""));
+        if (!isEnabled) {
+            LOGGER.warn("Not applying mixin '{}' as '{}' is disabled in config", name, baseName);
+        }
+        return isEnabled;
+    }
+
+    @Override
+    public List<String> getMixins() {
+        MixinEnvironment.Phase phase = MixinEnvironment.getCurrentEnvironment().getPhase();
+        if (phase == MixinEnvironment.Phase.DEFAULT) {
+            MixinEnvironment.Side side = MixinEnvironment.getCurrentEnvironment().getSide();
+            List<String> list = allMixins.stream()
+                    .filter(p -> !p.isClientOnly || side == MixinEnvironment.Side.CLIENT)
+                    .filter(p -> p.isLate == LateMixins.atLateStage)
+                    .map(p -> p.className)
+                    .filter(MixinConfigPlugin::isMixinClassApplied)
+                    .map(clz -> clz.replace("thaumicenergistics.mixin.", ""))
+                    .collect(Collectors.toList());
+            for (String mixin : list) {
+                LOGGER.debug("loading {}", mixin);
+            }
+            return list;
+        }
+        return null;
+    }
+
+    @Override
+    public void preApply(String s, ClassNode classNode, String s1, IMixinInfo iMixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String s, ClassNode classNode, String s1, IMixinInfo iMixinInfo) {
+
+    }
+}

--- a/src/main/resources/mixins.thaumicenergistics.json
+++ b/src/main/resources/mixins.thaumicenergistics.json
@@ -1,0 +1,15 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "thaumicenergistics.mixin",
+  "refmap": "mixins.thaumicenergistics.refmap.json",
+  "plugin": "thaumicenergistics.mixin.core.MixinConfigPlugin",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+  ],
+  "client": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/resources/mixins.thaumicenergistics.late.json
+++ b/src/main/resources/mixins.thaumicenergistics.late.json
@@ -1,0 +1,15 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "thaumicenergistics.mixin",
+  "refmap": "mixins.thaumicenergistics.refmap.json",
+  "plugin": "thaumicenergistics.mixin.core.MixinConfigPlugin",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+  ],
+  "client": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
Attempt one to fix a crash around the ThE terminals.

The bug occurs when trying to craft.
At GUI initialisation time, we get an access to the AE2 gui element via reflection containing the craft quantity. Later when Next is clicked, we get the craft quantity from this gui element. Despite safety checks when we get the AE2 element that it is not null, it somehow becomes null at the time Next is clicked, and an NPE occurs.

I am uncertain why the null occurs. However I have rewritten all the code around this area, removed the reflection and instead deferred accessing any element of the AE2 gui until as late as possible. Hopefully by this point, everything is initialised fully. It may help.

This addresses https://github.com/Delfayne/ThaumicEnergistics/issues/30