### PR TITLE
Fix import bus crashing on Advanced Alchemical Furnace

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -125,7 +125,9 @@ dependencies {
     compileOnly(libs.curse.inventoryTweaks)
     api(rfg.deobf(libs.curse.baubles.get().toString()))
     api(rfg.deobf(libs.curse.thaumcraft.get().toString()))
-    api(libs.curse.thaumicJei.get().toString())
+    api(rfg.deobf(libs.curse.thaumicAug.get().toString()))
+    api(rfg.deobf(libs.curse.aaf.get().toString()))
+    api(libs.curse.thaumicJei)
     api(rfg.deobf(libs.curse.ae2.get().toString()))
 
     // Testing mods

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ curse-top = { module = "curse.maven:the-one-probe-245211", version = "2667280" }
 curse-baubles = { module = "curse.maven:baubles-227083", version = "2518667" }
 curse-thaumcraft = { module = "curse.maven:thaumcraft-223628", version = "2629023" }
 curse-thaumicJei = { module = "curse.maven:thaumic-jei-285492", version = "2705304" }
+curse-thaumicAug = { module = "curse.maven:thaumic-augmentation-319441", version = "5129455" }
+curse-aaf = { module = "curse.maven:advanced-alchemical-furnace-960604", version = "5053524" }
 curse-ae2 = { module = "curse.maven:ae2-extended-life-570458", version = "4505114" }
 
 # Misc

--- a/src/main/java/thaumicenergistics/part/PartEssentiaExportBus.java
+++ b/src/main/java/thaumicenergistics/part/PartEssentiaExportBus.java
@@ -66,7 +66,9 @@ public class PartEssentiaExportBus extends PartSharedEssentiaBus {
 
     @Override
     public boolean canWork() {
-        return this.getConnectedTE() != null && this.config.hasAspects(); // We only want to run if there is something in the filter
+        // We only want to run if there is something in the filter
+        return this.getConnectedTE() instanceof IAspectContainer
+                && this.config.hasAspects();
     }
 
     @Override

--- a/src/main/java/thaumicenergistics/part/PartEssentiaExportBus.java
+++ b/src/main/java/thaumicenergistics/part/PartEssentiaExportBus.java
@@ -71,48 +71,49 @@ public class PartEssentiaExportBus extends PartSharedEssentiaBus {
 
     @Override
     protected TickRateModulation doWork() {
-        if (this.getConnectedTE() instanceof IAspectContainer) {
-            IAspectContainer container = (IAspectContainer) this.getConnectedTE();
-
-            IStorageGrid storageGrid = this.getGridNode().getGrid().getCache(IStorageGrid.class);
-            IMEMonitor<IAEEssentiaStack> storage = storageGrid.getInventory(this.getChannel());
-
-            for (Aspect aspect : this.config) { // Gather a list of aspects that can be put into the container
-                if (aspect == null)
-                    continue;
-                if (container.doesContainerAccept(aspect) && AEUtil.doesStorageContain(storage, aspect)) { // Can container hold the aspect + does ae2 hold the aspect
-                    // Simulate extract from ae2
-                    IAEEssentiaStack extracted = storage.extractItems(AEUtil.getAEStackFromAspect(aspect, this.calculateAmountToSend()), Actionable.SIMULATE, this.source);
-                    // Try add to container, since we can't simulate it
-                    int notAdded;
-                    // FIXME: Remove after issue fixed in TC.
-                    // https://github.com/Nividica/ThaumicEnergistics/issues/361
-                    // https://github.com/Azanor/thaumcraft-beta/issues/1604
-                    try {
-                        notAdded = container.addToContainer(extracted.getAspect(), (int) extracted.getStackSize());
-                    } catch (NullPointerException ignored) {
-                        if (!reportedWarning)
-                            ThELog.warn("container.addToContainer threw a NullPointerException. Thaumcraft Bug. Nividica/ThaumicEnergistics#361. Remove EssentiaExportBus from {}", this.hostTile != null ? this.hostTile.getPos() : this.getConnectedTE().getPos());
-                        reportedWarning = true;
-                        return TickRateModulation.IDLE;
-                    }
-                    reportedWarning = false;
-                    // Couldn't contain it all
-                    extracted.decStackSize(notAdded);
-
-                    if (extracted.getStackSize() == 0) {
-                        continue;
-                    }
-
-                    // Only remove from system the amount the container accepted
-                    storage.extractItems(extracted, Actionable.MODULATE, this.source);
-                    return TickRateModulation.FASTER; // Only do one every tick
-                }
-            }
-
-            return TickRateModulation.SLOWER;
+        if (!(this.getConnectedTE() instanceof IAspectContainer)) {
+            return TickRateModulation.IDLE;
         }
-        return TickRateModulation.IDLE;
+
+        IAspectContainer container = (IAspectContainer) this.getConnectedTE();
+
+        IStorageGrid storageGrid = this.getGridNode().getGrid().getCache(IStorageGrid.class);
+        IMEMonitor<IAEEssentiaStack> storage = storageGrid.getInventory(this.getChannel());
+
+        for (Aspect aspect : this.config) { // Gather a list of aspects that can be put into the container
+            if (aspect == null)
+                continue;
+            if (container.doesContainerAccept(aspect) && AEUtil.doesStorageContain(storage, aspect)) { // Can container hold the aspect + does ae2 hold the aspect
+                // Simulate extract from ae2
+                IAEEssentiaStack extracted = storage.extractItems(AEUtil.getAEStackFromAspect(aspect, this.calculateAmountToSend()), Actionable.SIMULATE, this.source);
+                // Try add to container, since we can't simulate it
+                int notAdded;
+                // FIXME: Remove after issue fixed in TC.
+                // https://github.com/Nividica/ThaumicEnergistics/issues/361
+                // https://github.com/Azanor/thaumcraft-beta/issues/1604
+                try {
+                    notAdded = container.addToContainer(extracted.getAspect(), (int) extracted.getStackSize());
+                } catch (NullPointerException ignored) {
+                    if (!reportedWarning)
+                        ThELog.warn("container.addToContainer threw a NullPointerException. Thaumcraft Bug. Nividica/ThaumicEnergistics#361. Remove EssentiaExportBus from {}", this.hostTile != null ? this.hostTile.getPos() : this.getConnectedTE().getPos());
+                    reportedWarning = true;
+                    return TickRateModulation.IDLE;
+                }
+                reportedWarning = false;
+                // Couldn't contain it all
+                extracted.decStackSize(notAdded);
+
+                if (extracted.getStackSize() == 0) {
+                    continue;
+                }
+
+                // Only remove from system the amount the container accepted
+                storage.extractItems(extracted, Actionable.MODULATE, this.source);
+                return TickRateModulation.FASTER; // Only do one every tick
+            }
+        }
+
+        return TickRateModulation.SLOWER;
     }
 
     @Nonnull

--- a/src/main/java/thaumicenergistics/part/PartEssentiaImportBus.java
+++ b/src/main/java/thaumicenergistics/part/PartEssentiaImportBus.java
@@ -67,6 +67,9 @@ public class PartEssentiaImportBus extends PartSharedEssentiaBus {
 
     @Override
     protected TickRateModulation doWork() {
+        if (!(this.getConnectedTE() instanceof IAspectContainer)) {
+            return TickRateModulation.IDLE;
+        }
         IAspectContainer container = (IAspectContainer) this.getConnectedTE();
         for (Aspect aspect : container.getAspects().getAspects()) {
             if (this.config.hasAspects() && !this.config.isInFilter(aspect)) // Check filter

--- a/src/main/java/thaumicenergistics/part/PartSharedEssentiaBus.java
+++ b/src/main/java/thaumicenergistics/part/PartSharedEssentiaBus.java
@@ -23,6 +23,7 @@ import thaumicenergistics.util.EssentiaFilter;
 import thaumicenergistics.util.inventory.ThEUpgradeInventory;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -95,6 +96,7 @@ public abstract class PartSharedEssentiaBus extends PartBase implements IGridTic
         return 1;
     }
 
+    @Nullable
     public TileEntity getConnectedTE() {
         TileEntity self = this.host.getTile();
         World w = self.getWorld();


### PR DESCRIPTION
Unable to reproduce, but there's some clear holes in the code that make for obvious patches.

A method shared between all buses, `#getConnectedTE` can return nulls. It appears to do so when the target is not chunkloaded.

The export bus implicitly checks for this, as it performs an `instanceof` check when running, which would also block nulls. The import bus makes no such checks. I've tightened up the logic around here so this should be fixed.

Fixes https://github.com/Delfayne/ThaumicEnergistics/issues/28