### PR TITLE
Fix crash for latest AE2-UEL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -128,6 +128,7 @@ dependencies {
     implementation(libs.curse.top)
 
     compileOnly(libs.curse.inventoryTweaks)
+    compileOnly(libs.curse.mouseTweaks)
     api(rfg.deobf(libs.curse.baubles.get().toString()))
     api(rfg.deobf(libs.curse.thaumcraft.get().toString()))
     api(rfg.deobf(libs.curse.thaumicAug.get().toString()))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,8 @@ curse-thaumcraft = { module = "curse.maven:thaumcraft-223628", version = "262902
 curse-thaumicJei = { module = "curse.maven:thaumic-jei-285492", version = "2705304" }
 curse-thaumicAug = { module = "curse.maven:thaumic-augmentation-319441", version = "5129455" }
 curse-aaf = { module = "curse.maven:advanced-alchemical-furnace-960604", version = "5053524" }
-curse-ae2 = { module = "curse.maven:ae2-extended-life-570458", version = "4505114" }
+curse-ae2 = { module = "curse.maven:ae2-extended-life-570458", version = "5028606" }
 
 # Misc
 curse-inventoryTweaks = { module = "curse.maven:inventory-tweaks-223094", version = "2482482" }
+curse-mouseTweaks = { module = "curse.maven:mouse-tweaks-60089", version = "3359843" }

--- a/src/main/java/thaumicenergistics/mixin/ae2/CraftAmountAccessor.java
+++ b/src/main/java/thaumicenergistics/mixin/ae2/CraftAmountAccessor.java
@@ -2,6 +2,7 @@ package thaumicenergistics.mixin.ae2;
 
 import appeng.client.gui.implementations.GuiCraftAmount;
 import appeng.client.gui.widgets.GuiNumberBox;
+import net.minecraft.client.gui.GuiTextField;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 import thaumicenergistics.annotation.ClientOnlyMixin;
@@ -12,5 +13,5 @@ import thaumicenergistics.annotation.LateMixin;
 @LateMixin
 public interface CraftAmountAccessor {
     @Accessor(remap = false)
-    GuiNumberBox getAmountToCraft();
+    GuiTextField getAmountToCraft();
 }


### PR DESCRIPTION
Fixes #30 

This problem occurs because in the latest version of AE-UEL, developers have modified the instance of this variable. In the latest version, the instance is no longer GuiNumberBox, but GuiTextField. It is speculated that it may be related to the support for mathematical expressions in the recent changes.

@Delfayne 


The developers of UEL have seen this error. Not sure if a compatible fix will be made for this issue. Temporarily set to draft
