### PR TITLE
Fix Essentia Terminal item filling

### DIFF
--- a/src/main/java/thaumicenergistics/network/packets/PacketUIAction.java
+++ b/src/main/java/thaumicenergistics/network/packets/PacketUIAction.java
@@ -65,7 +65,7 @@ public class PacketUIAction implements IMessage {
         if (nbt.hasKey("index")) {
             this.index = nbt.getInteger("index");
         }
-        if (nbt.hasKey("Cnt")) {
+        if (nbt.hasKey("Count")) {
             AEApi.instance().storage().storageChannels().forEach(channel -> {
                 if (requestedStack == null) {
                     try {


### PR DESCRIPTION
Partially fixes #42.

`requestedStack` was always null, because the nbt data was never read serverside. It always looked for a nbt tag with the key `cnt`, that doesn't exist. It should be `Count`. Probably just a small typo on your end.