### PR TITLE
Terminal sorting fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.parallel=true
 # Allow Gradle to cache build to avoid recompiling classes that did not change.
 org.gradle.caching=true
 # Mod Information
-modVersion=2.3.2
+modVersion=2.3.3
 mavenGroup=org.dv.minecraft.thaumicenergistics
 modArchiveName=thaumic-energistics-extended-life
 modName=Thaumic Energistics

--- a/src/main/java/thaumicenergistics/container/ContainerBaseConfigurable.java
+++ b/src/main/java/thaumicenergistics/container/ContainerBaseConfigurable.java
@@ -34,6 +34,10 @@ public abstract class ContainerBaseConfigurable extends ContainerBase implements
     @Override
     public void detectAndSendChanges() {
         if (ForgeUtil.isServer()) {
+            if (this.listeners.isEmpty()) {
+                // If the Player listener is not attached yet, no sense doing the checks
+                return;
+            }
             for (Settings setting : this.serverConfigManager.getSettings()) {
                 Enum<?> server = this.serverConfigManager.getSetting(setting);
                 Enum<?> client = this.clientConfigManager.getSetting(setting);


### PR DESCRIPTION
Terminal sort buttons were not (apparently) being persisted when closing and reopening the terminal.

As it turns out they were persisted fine. However the packet from the server to the client informing them of these changes fires ASAP, even before the Player had fully opened the terminal and the Player listener was not attached to the terminal. The packet disappears into the void.

(Again apparently) Easy fix, to wait for a listener to be attached first.

Linked to from here: https://github.com/Delfayne/ThaumicEnergistics/pull/49